### PR TITLE
replace fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For an introduction to the methodology and research behind HMNI, please refer to
 ### Python 3.5–3.8
 -  tensorflow
 -  scikit-learn
--  fuzzywuzzy
+-  rapidfuzz
 -  abydos
 -  unidecode
 

--- a/dev/model_building.ipynb
+++ b/dev/model_building.ipynb
@@ -176,7 +176,7 @@
    "outputs": [],
    "source": [
     "import unidecode\n",
-    "from fuzzywuzzy import fuzz\n",
+    "from rapidfuzz import fuzz\n",
     "\n",
     "import syllable_tokenizer\n",
     "\n",

--- a/hmni/matcher.py
+++ b/hmni/matcher.py
@@ -13,11 +13,7 @@ import numpy as np
 import pandas as pd
 from random import randint
 
-import warnings
-
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning)
-    from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from collections import Counter
 from hmni import syllable_tokenizer

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ tensorflow
 pandas>=0.25
 numpy
 unidecode
-fuzzywuzzy
+rapidfuzz
 abydos==0.5.0
 scikit-learn
 joblib

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'pandas >= 0.25',
     'numpy',
     'unidecode',
-    'fuzzywuzzy',
+    'rapidfuzz',
     'abydos == 0.5.0',
     'scikit-learn',
     'joblib'


### PR DESCRIPTION
FuzzyWuzzy is GPL Licensed and therefore can not be used in MIT licensed project. This Pull Request replaces FuzzyWuzzy with [RapidFuzz](https://github.com/maxbachmann/rapidfuzz), which implements the same algorithms. It is licensed in a compatible way (MIT License) and is faster than FuzzyWuzzy. 