### PR TITLE
set package versions to remove import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-tensorflow
+tensorflow<=2.7.4
 pandas>=0.25
-numpy
+numpy==1.19.2
 unidecode
 fuzzywuzzy
 abydos==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -29,13 +29,13 @@ setup_args = dict(
 )
 
 install_requires = [
-    'tensorflow',
+    'tensorflow <= 2.7.4',
     'pandas >= 0.25',
-    'numpy',
+    'numpy == 1.19.1',
     'unidecode',
     'fuzzywuzzy',
     'abydos == 0.5.0',
-    'scikit-learn',
+    'scikit-learn == 0.23.1',
     'joblib'
 ]
 


### PR DESCRIPTION
Fixing the package versions removes the import error as seen in Issue #21. Sklearn still gives warnings about the version so not the perfect fix, but the code is runnable again.